### PR TITLE
Add Contact CTA component to Home page

### DIFF
--- a/src/components/ContactCta.css
+++ b/src/components/ContactCta.css
@@ -1,0 +1,95 @@
+.contact-cta {
+  background-color: #ffffff;
+  padding: 120px 0 140px;
+}
+
+.contact-cta-inner {
+  max-width: 1300px;
+  margin: 0 auto;
+  padding: 0 40px;
+}
+
+.contact-cta-card {
+  background: #ffffff;
+  border-radius: 20px;
+  border: 1px solid #eef2f4;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.08);
+  padding: 60px 70px;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 40px;
+}
+
+.contact-cta-content {
+  max-width: 720px;
+}
+
+.contact-cta-eyebrow {
+  display: inline-block;
+  margin-bottom: 14px;
+  font-size: 12px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #005b8f;
+}
+
+.contact-cta-title {
+  font-size: 2.6rem;
+  color: #242424;
+  margin-bottom: 18px;
+  line-height: 1.2;
+}
+
+.contact-cta-text {
+  font-size: 1.1rem;
+  color: #4a4a4a;
+  line-height: 1.7;
+}
+
+.contact-cta-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 34px;
+  border-radius: 999px;
+  background-color: #135985;
+  color: #ffffff;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  white-space: nowrap;
+}
+
+.contact-cta-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(19, 89, 133, 0.25);
+}
+
+@media (max-width: 1024px) {
+  .contact-cta-card {
+    flex-direction: column;
+    text-align: center;
+    padding: 50px 40px;
+  }
+
+  .contact-cta-content {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .contact-cta {
+    padding: 90px 0 120px;
+  }
+
+  .contact-cta-card {
+    padding: 40px 28px;
+  }
+
+  .contact-cta-title {
+    font-size: 2.1rem;
+  }
+}

--- a/src/components/ContactCta.js
+++ b/src/components/ContactCta.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './ContactCta.css';
+
+function ContactCta() {
+  return (
+    <section className="contact-cta">
+      <div className="contact-cta-inner">
+        <div className="contact-cta-card">
+          <div className="contact-cta-content">
+            <span className="contact-cta-eyebrow">Let’s Talk</span>
+            <h2 className="contact-cta-title">Ready to start your next project?</h2>
+            <p className="contact-cta-text">
+              Speak with our engineering team about tailored solutions, timelines,
+              and how we can support your build from concept to completion.
+            </p>
+          </div>
+          <Link to="/contact" className="contact-cta-button">
+            Contact Us
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default ContactCta;

--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -6,6 +6,7 @@ import ToServices from '../ToServices';
 import Logo from '../Logo';
 import MiniAbout from '../MiniAbout';
 import Clients from '../Clients';
+import ContactCta from '../ContactCta';
 import { Helmet } from 'react-helmet';
 
 function Home () {
@@ -33,6 +34,7 @@ function Home () {
             <ToServices />
             <OurIndustries />
             <Clients />
+            <ContactCta />
         
         </>
     );


### PR DESCRIPTION
### Motivation
- Add a prominent call-to-action that directs users to the contact page and blends with the existing site design.
- Place the CTA beneath the clients section on the home page to capture users after social proof.
- Use a white background and card styling so the CTA integrates seamlessly with other page sections.

### Description
- Added a new component `ContactCta` implemented in `src/components/ContactCta.js` with associated styles in `src/components/ContactCta.css`.
- The CTA renders an eyebrow, heading, explanatory text and a `Link` button that navigates to `/contact` using `react-router-dom`.
- Imported and rendered `<ContactCta />` in `src/components/pages/Home.js` directly below the `<Clients />` section.
- Styling provides a white card treatment with responsive rules to match the site layout and typography.

### Testing
- Started the development server and the app compiled successfully with the new component included (`react-scripts start`), and the server reported a successful compile.
- Ran an automated Playwright script that visited `http://127.0.0.1:3000`, scrolled, and saved a full-page screenshot to `artifacts/contact-cta-home.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69621d500278832d889d8f4c8b2a064b)